### PR TITLE
Add sign-up link on login page

### DIFF
--- a/FlaskProject/app.py
+++ b/FlaskProject/app.py
@@ -238,6 +238,9 @@ def login():
                                 <div class="mt-3 text-center">
                                     <small class="text-muted">Default: admin / admin123</small>
                                 </div>
+                                <div class="mt-2 text-center">
+                                    <a href="/signup">Don't have an account? Sign up</a>
+                                </div>
                                 <div class="mt-3">
                                     <h6>Available Roles:</h6>
                                     <small class="text-muted">

--- a/FlaskProject/templates/auth/login.html
+++ b/FlaskProject/templates/auth/login.html
@@ -36,6 +36,9 @@
                             <i class="fas fa-info-circle"></i> Default credentials: admin / admin123
                         </small>
                     </div>
+                    <div class="mt-2 text-center">
+                        <a href="{{ url_for('signup') }}">Don't have an account? Sign up</a>
+                    </div>
                 </div>
                 <div class="card-footer text-center text-muted">
                     <small>&copy; 2025 Hostel Management System</small>


### PR DESCRIPTION
## Summary
- expose `signup` route from the login page template
- add same link to fallback login HTML for completeness

## Testing
- `pytest -k none -q` *(fails: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684f8b10a10c8332ace4a38e2160d06b